### PR TITLE
Adding an overflow option that will draw words even if they don't fit 

### DIFF
--- a/d3.layout.cloud.js
+++ b/d3.layout.cloud.js
@@ -15,6 +15,7 @@
         timeInterval = Infinity,
         event = d3.dispatch("word", "end"),
         timer = null,
+        overflow = false,
         cloud = {};
 
     cloud.start = function() {
@@ -100,8 +101,15 @@
         tag.x = startX + dx;
         tag.y = startY + dy;
 
+        // if (tag.width < size[0] && tag.height <size[1] &&
+        //     (tag.x + tag.x0 < 0 || tag.y + tag.y0 < 0 ||
+        //     tag.x + tag.x1 > size[0] || tag.y + tag.y1 > size[1])) continue;
         if (tag.x + tag.x0 < 0 || tag.y + tag.y0 < 0 ||
-            tag.x + tag.x1 > size[0] || tag.y + tag.y1 > size[1]) continue;
+            tag.x + tag.x1 > size[0] || tag.y + tag.y1 > size[1]) {
+          if (!overflow) {
+            continue;
+          }
+        }
         // TODO only check for collisions within current bounds.
         if (!bounds || !cloudCollide(tag, board, size[0])) {
           if (!bounds || collideRects(tag, bounds)) {
@@ -186,6 +194,12 @@
     cloud.padding = function(x) {
       if (!arguments.length) return padding;
       padding = d3.functor(x);
+      return cloud;
+    };
+
+    cloud.overflow = function(x) {
+      if (!arguments.length) return overflow;
+      overflow = d3.functor(x);
       return cloud;
     };
 

--- a/d3.layout.cloud.js
+++ b/d3.layout.cloud.js
@@ -101,9 +101,6 @@
         tag.x = startX + dx;
         tag.y = startY + dy;
 
-        // if (tag.width < size[0] && tag.height <size[1] &&
-        //     (tag.x + tag.x0 < 0 || tag.y + tag.y0 < 0 ||
-        //     tag.x + tag.x1 > size[0] || tag.y + tag.y1 > size[1])) continue;
         if (tag.x + tag.x0 < 0 || tag.y + tag.y0 < 0 ||
             tag.x + tag.x1 > size[0] || tag.y + tag.y1 > size[1]) {
           if (!overflow) {

--- a/examples/simple_with_overflow.html
+++ b/examples/simple_with_overflow.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body>
+<script src="../lib/d3/d3.js"></script>
+<script src="../d3.layout.cloud.js"></script>
+<script>
+//OneBigWord will (usually) not show up, because it doesn't fit in
+var fill = d3.scale.category20();
+
+var words = [
+        "Hello", "world", "normally", "you", "want", "more", "words",
+        "than", "this", "OneBigWord"].map(function(d) {
+        return {text: d, size: 10 + Math.random() * 90};
+        });
+
+  d3.layout.cloud().size([300, 300])
+      .words(words)
+      .padding(5)
+      .overflow(true)
+      .rotate(function() { return ~~(Math.random() * 2) * 90; })
+      .font("Impact")
+      .fontSize(function(d) { return d.size; })
+      .on("end", draw)
+      .start();
+
+  function draw(words) {
+    d3.select("body").append("svg")
+        .attr("width", 300)
+        .attr("height", 300)
+      .append("g")
+        .attr("transform", "translate(150,150)")
+      .selectAll("text")
+        .data(words)
+      .enter().append("text")
+        .style("font-size", function(d) { return d.size + "px"; })
+        .style("font-family", "Impact")
+        .style("fill", function(d, i) { return fill(i); })
+        .attr("text-anchor", "middle")
+        .attr("transform", function(d) {
+          return "translate(" + [d.x, d.y] + ")rotate(" + d.rotate + ")";
+        })
+        .text(function(d) { return d.text; });
+  }
+</script>


### PR DESCRIPTION
john-guerra commented on Apr 28, 2014
When creating word clouds in svgs with small sizes the big words (arguably the most important ones) might not be drawn because they won't fit. This change adds an overflow option to the wordcloud that will draw words even if they don't fit on the available space, this will truncate words, but at least will guarantee that the most significant word is (at least partially) displayed. The default value is false.